### PR TITLE
feat(index.html): update content to reflect new versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
           <ul class="nav navbar-nav">
             <li><a href="#about">about</a></li>
             <li><a href="#resources">resources</a></li>
-            <li><a target="_new" href="http://blog.vrtk.io">blog</a></li>
+            <li><a target="_new" href="https://www.redbubble.com/people/vrtk/shop">swag</a></li>
           </ul>
         </div>
       </div>
@@ -61,7 +61,7 @@
           <img class="first-slide" src="images/vrtkv4farmyard.jpg" alt="a view of the farm yard example scene from VRTK version 4">
           <div class="carousel-caption">
             <h1>VRTK v4 is here</h1>
-            <a class="btn btn-primary" href="https://github.com/ExtendRealityLtd/VRTK" target="_new" role="button" title="Get a copy of VRTK v4 beta from GitHub">explore beta</a>
+            <a class="btn btn-primary" href="https://github.com/ExtendRealityLtd/VRTK" target="_new" role="button" title="Get a copy of VRTK v4 farm yard example project from GitHub">explore features</a>
           </div>
         </div>
         <div class="item">
@@ -111,12 +111,12 @@
           <div class="resources-list">
             <div class="resource row">
               <div class="col-sm-4 resource-cell">
-                <img src="images/resource-github.jpg" class="img-responsive"  alt="GitHub Site">
+                <img src="images/resource-unity.jpg" class="img-responsive" alt="Unity 3D Logo">
               </div>
               <div class="content col-sm-8 resource-cell">
-                <h4>GitHub</h4>
-                <p>The GitHub organization page is the home of all the Extend Reality packages including the VRTK farmyard example. The GitHub repositories have the latest features and updates. You can even fork the repo, make changes, new features and contribute back.</p>
-                <a class="btn btn-primary" href="https://github.com/ExtendRealityLtd" target="_new" role="button">visit github</a>
+                <h4>Unity Asset Store</h4>
+                <p>The easiest way to get started with VRTK v4 is to download the VRTK v4 Tilia Package Importer from the Unity Asset Store.</p>
+                <a class="btn btn-primary" href="https://assetstore.unity.com/packages/tools/utilities/vrtk-v4-tilia-package-importer-214936" target="_new" role="button">visit unity asset store</a>
               </div>
             </div>
             <div class="resource row right-align resource-alt">
@@ -131,12 +131,12 @@
             </div>
             <div class="resource row">
               <div class="col-sm-4 resource-cell">
-                <img src="images/resource-unity.jpg" class="img-responsive" alt="Unity 3D Logo">
+                <img src="images/resource-github.jpg" class="img-responsive"  alt="GitHub Site">
               </div>
               <div class="content col-sm-8 resource-cell">
-                <h4>Unity Asset Store</h4>
-                <p>The official releases for VRTK can also be downloaded straight into the Unity3d software via the Unity Asset Store. This is the easiest way to get VRTK into a Unity3d project and get building as soon as possible.</p>
-                <a class="btn btn-primary" href="https://assetstore.unity.com/packages/tools/vrtk-virtual-reality-toolkit-vr-toolkit-64131" target="_new" role="button">visit unity asset store</a>
+                <h4>GitHub</h4>
+                <p>The GitHub organization page is the home of all the Extend Reality packages including the VRTK farmyard example and VRTK v4 Bowling tutorial. The GitHub repositories have the latest features and updates. You can even fork the repo, make changes, new features and contribute back.</p>
+                <a class="btn btn-primary" href="https://github.com/ExtendRealityLtd" target="_new" role="button">visit github</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
The blog link has been removed as the blog was never used and in
place is now the red bubble shop link.

The Explore Beta has been replaced with Explore Features as Tilia
is not in beta so it makes little sense.

The Unity Asset Store blurb and GitHub blurb has been swapped in
position and the Unity Asset Store link is now for the new importer.